### PR TITLE
refactor: separate prod config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM eclipse-temurin:21-jdk AS runtime
 WORKDIR /app
 COPY --from=build /app/target/auth-microservice-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE ${PORT}
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=prod"]

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+logging.level.org.springframework.security=DEBUG
+logging.level.org.keycloak=DEBUG

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,17 @@
+eureka.instance.hostname=${EUREKA_INSTANCE_HOSTNAME:localhost}
+eureka.instance.prefer-ip-address=false
+eureka.instance.non-secure-port-enabled=true
+#eureka.instance.secure-port-enabled=true
+#eureka.instance.secure-port=${PORT:443}
+eureka.instance.home-page-url=https://${eureka.instance.hostname}/
+eureka.instance.status-page-url=https://${eureka.instance.hostname}/actuator/info
+eureka.instance.health-check-url=https://${eureka.instance.hostname}/actuator/health
+eureka.client.enabled=true
+
+# Disable automatic hostname resolution
+eureka.instance.metadata-map.hostname=${eureka.instance.hostname}
+eureka.instance.metadata-map.port=${PORT:443}
+eureka.instance.metadata-map.securePort=443
+
+logging.level.org.springframework.security=INFO
+logging.level.org.keycloak=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,40 +1,25 @@
 spring.application.name=auth-microservice
+spring.profiles.active=local
+
 server.port=${PORT:0}
 spring.main.web-application-type=reactive
 spring.webflux.base-path=/api/auth
 
-eureka.instance.hostname=${EUREKA_INSTANCE_HOSTNAME:localhost}
-eureka.instance.prefer-ip-address=false
-eureka.instance.non-secure-port-enabled=false
-eureka.instance.secure-port-enabled=true
-eureka.instance.secure-port=${PORT:443}
-eureka.instance.home-page-url=https://${eureka.instance.hostname}/
-eureka.instance.status-page-url=https://${eureka.instance.hostname}/actuator/info
-eureka.instance.health-check-url=https://${eureka.instance.hostname}/actuator/health
 eureka.instance.instance-id=${spring.application.name}:${random.uuid}
-eureka.client.enabled=true
 eureka.client.service-url.defaultZone=${EUREKA_URL:http://localhost:8761/eureka}
-
-# Disable automatic hostname resolution
-eureka.instance.metadata-map.hostname=${eureka.instance.hostname}
-eureka.instance.metadata-map.port=${PORT:443}
-eureka.instance.metadata-map.securePort=443
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_ISSUER_URI:http://localhost:9090/realms/nullius-real-estate-realm}
 
 spring.security.oauth2.client.registration.keycloak.client-id=${KEYCLOAK_CLIENT_ID:auth-service-client}
-spring.security.oauth2.client.registration.keycloak.client-secret=${KEYCLOAK_CLIENT_SECRET:cDm5nFmwXPgpVy6gP2haEV7mjKgJZXAN}
+spring.security.oauth2.client.registration.keycloak.client-secret=${KEYCLOAK_CLIENT_SECRET:xhQBzLo4TGqGhFl1sFMZ3cG1LOQrirjZ}
 spring.security.oauth2.client.registration.keycloak.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.keycloak.redirect-uri=${KEYCLOAK_REDIRECT_URI:http://localhost:8090/auth/login/oauth2/code/keycloak}
 spring.security.oauth2.client.provider.keycloak.issuer-uri=${KEYCLOAK_ISSUER_URI:http://localhost:9090/realms/nullius-real-estate-realm}
 
 keycloak.admin.client-id=${KEYCLOAK_ADMIN_CLIENT_ID:admin-cli}
-keycloak.admin.client-secret=${KEYCLOAK_ADMIN_CLIENT_SECRET:gNjpVJHVrqF4q28Q30jAFzLaBg94gRN9}
+keycloak.admin.client-secret=${KEYCLOAK_ADMIN_CLIENT_SECRET:mID0M1ZdbU0iURk6PhDc9PSlyblUc8LH}
 keycloak.admin.realm=${KEYCLOAK_ADMIN_REALM:nullius-real-estate-realm}
 keycloak.admin.url=${KEYCLOAK_ADMIN_URL:http://localhost:9090}
-
-logging.level.org.springframework.security=INFO
-logging.level.org.keycloak=INFO
 
 # Documentation
 springdoc.api-docs.enabled=true


### PR DESCRIPTION
This pull request includes several changes to the configuration files and Dockerfile for the `auth-microservice` project. The changes primarily focus on setting up different profiles for local and production environments, adjusting logging levels, and updating Eureka instance configurations.

Configuration updates:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R2-L38): Set the default active profile to `local` and removed Eureka instance configurations that were moved to profile-specific files. Updated Keycloak client secrets.

* [`src/main/resources/application-local.properties`](diffhunk://#diff-4d8bbe5db39e2956bb9e178c5a8105fcfd99ce2f027450fa47e22083d6849221R1-R2): Added debug logging levels for Spring Security and Keycloak to assist with local development.

* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efR1-R17): Added Eureka instance configurations and set logging levels to `INFO` for production.

Dockerfile update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L11-R11): Modified the `ENTRYPOINT` to activate the `prod` profile when running the application.