### PR TITLE
feat: add endpoint to check if user is verified in Keycloak

### DIFF
--- a/src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt
+++ b/src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt
@@ -18,6 +18,7 @@ class SecurityConfig {
                 it.pathMatchers(
                     "/login",
                     "/register",
+                    "/user/{keycloakUserId}/is-verified",
 
 //                    Docs
                     "/webjars/**",


### PR DESCRIPTION
This pull request includes several changes to the `AuthController` class and the `SecurityConfig` class in the `auth_microservice` module. The main focus is on adding a new endpoint to check if a user is verified and refactoring the code to use a common method for obtaining the admin token.

### New Feature:
* Added a new endpoint `/user/{keycloakUserId}/is-verified` to check if a user is verified. (`src/main/kotlin/com/nullius_real_estate/auth_microservice/controller/AuthController.kt`)

### Code Refactoring:
* Refactored the `deleteUserInKeycloak` and `createUserInKeycloak` methods to use the new `getAdminToken` method for obtaining the admin token. (`src/main/kotlin/com/nullius_real_estate/auth_microservice/controller/AuthController.kt`) [[1]](diffhunk://#diff-2563289c5bfe4817bca408cbc1668c9d170565035054e117e71d43e209974fb9L126-R149) [[2]](diffhunk://#diff-2563289c5bfe4817bca408cbc1668c9d170565035054e117e71d43e209974fb9L137-R166) [[3]](diffhunk://#diff-2563289c5bfe4817bca408cbc1668c9d170565035054e117e71d43e209974fb9L149-R175)
* Added the `getAdminToken` method to centralize the logic for obtaining the admin token. (`src/main/kotlin/com/nullius_real_estate/auth_microservice/controller/AuthController.kt`)

### Supporting Changes:
* Added a new path matcher for the `/user/{keycloakUserId}/is-verified` endpoint in the `SecurityConfig` class. (`src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt`)
* Imported the `PathVariable` annotation in the `AuthController` class to support the new endpoint. (`src/main/kotlin/com/nullius_real_estate/auth_microservice/controller/AuthController.kt`)