### PR TITLE
feat: add endpoint to check if user is verified in Keycloak

### DIFF
--- a/src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt
+++ b/src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt
@@ -19,6 +19,7 @@ class SecurityConfig {
                     "/login",
                     "/register",
                     "/user/{keycloakUserId}/is-verified",
+                    "/user/{keycloakUserId}/resend-verification-email",
 
 //                    Docs
                     "/webjars/**",


### PR DESCRIPTION
This pull request introduces a new feature to the authentication microservice by adding functionality to resend verification emails. The most important changes are the addition of a new endpoint and the implementation of the logic to send verification emails.

New feature implementation:

* [`src/main/kotlin/com/nullius_real_estate/auth_microservice/SecurityConfig.kt`](diffhunk://#diff-1165ca5e9eda15eecd5a93436026de0a158ef10008e57f96b0206e87c5059cadR22): Added a new endpoint `/user/{keycloakUserId}/resend-verification-email` to the security configuration.
* `src/main/kotlin/com/nullius_real_estate/auth_microservice/controller/AuthController.kt`: 
  * Introduced a new method `resendVerificationEmail` to handle POST requests to the new endpoint.
  * Updated the user registration flow to send a verification email upon successful registration.
  * Added a private method `sendVerificationEmail` to encapsulate the logic for sending verification emails using the Keycloak admin API.